### PR TITLE
Use secure_getenv() when it's available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/lib/hesiod.h])
 AC_CONFIG_HEADERS([config.h])
+AC_USE_SYSTEM_EXTENSIONS
 
 # Checks for programs.
 AC_PROG_CC
@@ -76,7 +77,7 @@ AC_EGREP_HEADER([pw_expire], [pwd.h],
 # Checks for library functions.
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([strchr strdup])
+AC_CHECK_FUNCS([strchr strdup secure_getenv])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/src/lib/hesiod.c
+++ b/src/lib/hesiod.c
@@ -99,6 +99,17 @@ static int read_config_file(struct hesiod_p *ctx, const char *filename);
 static char **get_txt_records(struct hesiod_p *ctx, const char *name);
 static int cistrcmp(const char *s1, const char *s2);
 
+static const char *hesiod_getenv(const char *e)
+{
+  if ((getuid() != geteuid()) || (getgid() != getegid()))
+    return NULL;
+#ifdef HAVE_SECURE_GETENV
+  return secure_getenv(e);
+#else
+  return getenv(e);
+#endif
+}
+
 /* This function is called to initialize a hesiod_p. */
 int hesiod_init(void **context)
 {
@@ -109,13 +120,13 @@ int hesiod_init(void **context)
   if (ctx)
     {
       *context = ctx;
-      configname = ((getuid() == geteuid()) && (getgid() == getegid())) ? getenv("HESIOD_CONFIG") : NULL;
+      configname = hesiod_getenv("HESIOD_CONFIG");
       if (!configname)
 	configname = SYSCONFDIR "/hesiod.conf";
       if (read_config_file(ctx, configname) >= 0)
 	{
 	  /* The default rhs can be overridden by an environment variable. */
-	  p = ((getuid() == geteuid()) && (getgid() == getegid())) ? getenv("HES_DOMAIN") : NULL;
+	  p = hesiod_getenv("HES_DOMAIN");
 	  if (p)
 	    {
 	      if (ctx->rhs)


### PR DESCRIPTION
Factor out logic that attempts to only consult the environment when it's safe to do so into its own function, and use secure_getenv() instead of getenv() if it's available.  Original report from
https://bugzilla.redhat.com/show_bug.cgi?id=1332508
