### PR TITLE
Only free ctx->rhs if allocating ctx succeeded.

### DIFF
--- a/src/lib/hesiod.c
+++ b/src/lib/hesiod.c
@@ -144,16 +144,13 @@ int hesiod_init(void **context)
 	  else
 	    return 0;
 	}
+      free(ctx->lhs);
+      free(ctx->rhs);
+      free(ctx);
     }
   else
     errno = ENOMEM;
 
-  if (ctx->lhs)
-    free(ctx->lhs);
-  if (ctx->rhs)
-    free(ctx->rhs);
-  if (ctx)
-    free(ctx);
   return -1;
 }
 


### PR DESCRIPTION
Also, we don't need to null-test prior to a free call, it is fine
by C99. so get rid of those checks.