### PR TITLE
Add support for libidn2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ compiler:
   - clang
   - gcc
 before_install:
-  - sudo apt-get install -qq autotools-dev libidn11-dev
+  - sudo apt-get install -qq autotools-dev libidn11-dev libidn2-0-dev
 before_script:
   - ./autogen.sh
 script: ./configure && make V=1 && make check V=1

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,17 @@ AC_ARG_WITH([libidn-headers],
        [CFLAGS="$CFLAGS -I$with_libidn_headers"],
        []) 
 
+AC_ARG_WITH([libidn2],
+  [AS_HELP_STRING([--with-libidn2], [Support IDN (needs GNU libidn2) @<:@check@:>@])],
+  [with_libidn2="$withval"],
+  [with_libidn2="check"])
+AS_IF([test x"$with_libidn2" != xno],
+  [AC_SEARCH_LIBS([idn2_check_version], [idn2],
+    [AC_DEFINE([HAVE_LIBIDN2], [1], [Define if libidn2 is available.])],
+    [AS_IF([test x"$with_idn2" = xcheck],
+      [AC_MSG_WARN([Unable to find libidn2.])],
+      [AC_MSG_ERROR([--with-libidn2 was given but libidn2 was not found.])])])])
+
 AC_CHECK_LIB([resolv], [res_mkquery], [], [
     AC_MSG_CHECKING([if res_mkquery is provided by libresolv with mangled symbols])
     save_LIBS="$LIBS"

--- a/src/lib/hesiod.c
+++ b/src/lib/hesiod.c
@@ -74,6 +74,9 @@ static const char rcsid[] = "$Id: hesiod.c,v 1.30 2002-04-03 21:40:55 ghudson Ex
 #include <idna.h>
 #include <idn-free.h>
 #endif
+#ifdef HAVE_LIBIDN2
+#include <idn2.h>
+#endif
 #include "hesiod.h"
 
 /* A few operating systems don't define this. */
@@ -246,6 +249,15 @@ char *hesiod_to_bind(void *context, const char *name, const char *type)
     }
   ret = strdup(idn_ret);
   idn_free(idn_ret);
+#elif HAVE_LIBIDN2
+  rc = idn2_to_ascii_lz(bindname, &idn_ret, 0);
+  if (rc != IDN2_OK)
+    {
+      errno = EINVAL;
+      return NULL;
+    }
+  ret = strdup(idn_ret);
+  idn2_free(idn_ret);
 #else
   ret = strdup(bindname);
 #endif


### PR DESCRIPTION
[libidn2](https://www.gnu.org/software/libidn/#libidn2) is stable now, and slowly being adopted more widely. Here's a patch to add support for it as desired.

Some projects are simply dropping `libidn` 1.x support like `curl` and `wget`, but a minimally-invasive change by logic would seem to have a better chance of not being rejected. Tested with `./configure --with-libidn2 --without-libidn` and it built fine.

Please feel free to sanity check this, I do not claim to do C well, and stupidity is not above me 😄.